### PR TITLE
fixes #8646 - use new smart proxy auth filters

### DIFF
--- a/app/controllers/api/v2/abrt_reports_controller.rb
+++ b/app/controllers/api/v2/abrt_reports_controller.rb
@@ -5,7 +5,7 @@ module Api
       include Foreman::Controller::SmartProxyAuth
       include AbrtReportsHelper
 
-      add_puppetmaster_filters :create
+      add_smart_proxy_filters :create, :features => 'ABRT'
 
       def create
         begin

--- a/db/seeds.d/50-abrt_seeds.rb
+++ b/db/seeds.d/50-abrt_seeds.rb
@@ -1,0 +1,2 @@
+# Create feature for Smart Proxy
+Feature.find_or_create_by_name('ABRT')


### PR DESCRIPTION
This should let any Proxy that has the ABRT plugin enabled send reports, instead of relying on Chef/Puppet.  This feature was just introduced in https://github.com/theforeman/foreman/pull/1975.
