### PR TITLE
Added missing API permission

### DIFF
--- a/lib/foreman_abrt/engine.rb
+++ b/lib/foreman_abrt/engine.rb
@@ -28,7 +28,10 @@ module ForemanAbrt
         security_block :foreman_abrt do
           permission :view_abrt_reports,    {:abrt_reports => [:index, :show, :auto_complete_search] }
           permission :destroy_abrt_reports, {:abrt_reports => [:destroy] }
-          permission :upload_abrt_reports,  {:abrt_reports => [:create] }
+          permission :upload_abrt_reports,  {
+            :abrt_reports => [:create],
+            :"api/v2/abrt_reports" => [:create]
+          }
           permission :forward_abrt_reports, {:abrt_reports => [:forward] }
         end
 


### PR DESCRIPTION
API for report creation was missing a permission. Found by our unit test
checker:

```
  1) Failure:
AccessPermissionsTest#test_0872_route api/v2/abrt_reports/create should have a permission that grants access [test/lib/foreman/access_permissions_test.rb:65]:
Expected [] to not be equal to [].
```
