### PR TITLE
Update Fix Rails versioned migrations for Rails 5

### DIFF
--- a/db/migrate/20140414095631_create_abrt_reports.rb
+++ b/db/migrate/20140414095631_create_abrt_reports.rb
@@ -1,4 +1,4 @@
-class CreateAbrtReports < ActiveRecord::Migration
+class CreateAbrtReports < ActiveRecord::Migration[4.2]
   def change
     create_table :abrt_reports do |t|
       t.references :host, :null => false

--- a/db/migrate/20140909170102_abrt_reports_drop_timestamps.rb
+++ b/db/migrate/20140909170102_abrt_reports_drop_timestamps.rb
@@ -1,4 +1,4 @@
-class AbrtReportsDropTimestamps < ActiveRecord::Migration
+class AbrtReportsDropTimestamps < ActiveRecord::Migration[4.2]
   def change
     remove_timestamps :abrt_reports
   end


### PR DESCRIPTION
Hi,
On foreman 1.17 this plugin doesn't work because of the versioned Rails Migrations.
Versioning to 4.2 fixed the issue.

Cheers,
Hristo