### PR TITLE
Fixes #28994 - Add description to plugin roles

### DIFF
--- a/lib/foreman_abrt/engine.rb
+++ b/lib/foreman_abrt/engine.rb
@@ -33,7 +33,8 @@ module ForemanAbrt
         end
 
         # Add a new role
-        role 'ABRT reports handling', [:view_abrt_reports, :destroy_abrt_reports, :upload_abrt_reports, :forward_abrt_reports]
+        role 'ABRT reports handling', [:view_abrt_reports, :destroy_abrt_reports, :upload_abrt_reports, :forward_abrt_reports],
+             'TODO: Description'
 
         #add menu entry
         menu :top_menu, :template,

--- a/lib/foreman_abrt/engine.rb
+++ b/lib/foreman_abrt/engine.rb
@@ -34,7 +34,7 @@ module ForemanAbrt
 
         # Add a new role
         role 'ABRT reports handling', [:view_abrt_reports, :destroy_abrt_reports, :upload_abrt_reports, :forward_abrt_reports],
-             'TODO: Description'
+             'Role granting permissions for ABRT reportings plugin/'
 
         #add menu entry
         menu :top_menu, :template,


### PR DESCRIPTION
PR is part of  [Add default descriptions to all roles added from plugins](https://projects.theforeman.org/issues/28936) task.